### PR TITLE
Fix for players name ending in -2

### DIFF
--- a/AODamageMeter/Character.cs
+++ b/AODamageMeter/Character.cs
@@ -184,7 +184,7 @@ namespace AODamageMeter
             => name != null && name.Length > 3 && name.Length < 13
             && IsUppercase(name[0])
             && (name.Skip(1).All(IsLowercaseOrDigit)
-                || name.EndsWith("-1") && name.Skip(1).Take(name.Length - 3).All(IsLowercaseOrDigit));
+                || (name.EndsWith("-1")|| name.EndsWith("-2")) && name.Skip(1).Take(name.Length - 3).All(IsLowercaseOrDigit));
 
         public bool FitsPetNamingConventions() => FitsPetNamingConventions(Name);
         public static bool FitsPetNamingConventions(string name)


### PR DESCRIPTION
Players name ending in -2 will get tagged as an NPC, this fix ensures they are correctly tagged as a player. (Yes they do exist)